### PR TITLE
[CSA-4612] Bump "rdoc" version to 6.6.3.1 to patch high vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
       timeout
     net-smtp (0.4.0.1)
       net-protocol
+    nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.2-x86_64-darwin)
       racc (~> 1.4)
     psych (5.1.2)
@@ -121,7 +123,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.1.0)
-    rdoc (6.6.2)
+    rdoc (6.6.3.1)
       psych (>= 4.0.0)
     reline (0.4.3)
       io-console (~> 0.5)
@@ -139,7 +141,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    stringio (3.1.0)
+    stringio (3.1.1)
     thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -152,6 +154,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-23
 
 DEPENDENCIES


### PR DESCRIPTION
**Description**

In order to attain and maintain NIST compliance, we must continuously fix critical and high level vulnerabilities in all software assets we own, including this repo. This version bump addresses a high level vulnerability in the "rdoc" dependency by bumping it to the fixed patch version.

**Risk Analysis**

[RDoc](https://github.com/ruby/rdoc) as a plugin generates HTML assets for existing markdown documentation. This plugin should not affect any business logic contained within the fork of this gem. Other plugins affected by this command are [stringio](https://github.com/ruby/stringio). I went ahead and ran a global search on any references to instances of it in the prodigy-identity-service, and there are 0 (`StringIO`, `stringio`). The same search in this repo only listed the `gemfile.lock` as a reference.

**Manual Testing**

* Ran the `rdoc` command on this repo to ensure no errors were produced during asset generation (note the new version on the bottom-left):

![image](https://github.com/SMARTeacher/sparkpost_rails/assets/73499029/89c91765-49eb-4d56-8f76-be374e126914)

* Ran `bundle exec rspec` to ensure all tests are passing:

![image](https://github.com/SMARTeacher/sparkpost_rails/assets/73499029/2b261bec-60ca-4582-8670-3d87cb54bf6f)