### PR TITLE
feat: [CSA-5897] bump Rack version to resolve security vulnerability 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sparkpost_rails (1.5.5)
       actionmailer (> 6.1.0, < 8.0.0)
-      rack (~> 3.2, >= 3.2.4)
+      rack (~> 3.1.18, >= 3.1.18)
       railties (> 6.1.0, < 8.0.0)
 
 GEM
@@ -107,7 +107,7 @@ GEM
       stringio
     public_suffix (5.0.4)
     racc (1.8.1)
-    rack (3.2.4)
+    rack (3.1.19)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     sparkpost_rails (1.5.5)
       actionmailer (> 6.1.0, < 8.0.0)
+      rack (~> 3.2, >= 3.2.4)
       railties (> 6.1.0, < 8.0.0)
 
 GEM
@@ -106,7 +107,7 @@ GEM
       stringio
     public_suffix (5.0.4)
     racc (1.8.1)
-    rack (3.1.15)
+    rack (3.2.4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/sparkpost_rails.gemspec
+++ b/sparkpost_rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     s.add_dependency rails_gem, '> 6.1.0', '< 8.0.0'
   end
 
-  s.add_dependency "rack", '~> 3.2', '>= 3.2.4'
+  s.add_dependency "rack", '~> 3.1.18', '>= 3.1.18'
 
 s.add_development_dependency "rspec", '>= 3.4.0'
   s.add_development_dependency "webmock", '>= 1.24.2'

--- a/sparkpost_rails.gemspec
+++ b/sparkpost_rails.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
     s.add_dependency rails_gem, '> 6.1.0', '< 8.0.0'
   end
 
+  s.add_dependency "rack", '~> 3.2', '>= 3.2.4'
+
 s.add_development_dependency "rspec", '>= 3.4.0'
   s.add_development_dependency "webmock", '>= 1.24.2'
 end


### PR DESCRIPTION
ticket: https://prodigygame.atlassian.net/browse/CSA-5897

This PR bumps the `Rack` dependency to version `3.2.4`

https://github.com/SMARTeacher/sparkpost_rails/security/dependabot/143