### PR TITLE
Loosen deps for Rails 8+ compat

### DIFF
--- a/sparkpost_rails.gemspec
+++ b/sparkpost_rails.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
   s.test_files = Dir["{spec}/**/*"]
 
   %w[actionmailer railties].each do |rails_gem|
-    s.add_dependency rails_gem, '> 6.1.0', '< 8.0.0'
+    s.add_dependency rails_gem, '> 6.1.0', '< 9.0.0'
   end
 
-  s.add_dependency "rack", '~> 3.1.18', '>= 3.1.18'
+  s.add_dependency "rack", '~> 3.1'
 
 s.add_development_dependency "rspec", '>= 3.4.0'
   s.add_development_dependency "webmock", '>= 1.24.2'


### PR DESCRIPTION
## Summary
- Widen `actionmailer`/`railties` upper bound from `< 8.0.0` to `< 9.0.0`
- Loosen `rack` from `~> 3.1.18` to `~> 3.1`

Needed to unblock Rails 8.x upgrades in prodigy-identity-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)